### PR TITLE
add treeview to package-requires of inspector.el

### DIFF
--- a/inspector.el
+++ b/inspector.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/mmontone/emacs-inspector
 ;; Keywords: debugging, tool, lisp, development
 ;; Version: 0.10
-;; Package-Requires: ((emacs "27.1"))
+;; Package-Requires: ((emacs "27.1") (treeview "1.1.0"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
This is necessary so that treeview is also included as a requirement in the generated inspector-pkg.el file.