### PR TITLE
Fix the 'Package-Requires' for the melpa

### DIFF
--- a/inspector.el
+++ b/inspector.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/mmontone/emacs-inspector
 ;; Keywords: debugging, tool, lisp, development
 ;; Version: 0.29
-;; Package-Requires: ((emacs "27.1"))
+;; Package-Requires: ((emacs "27.1") (treeview "1.1.0"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Hi,

After install the `emacs-inspector` from the melpa, the dependency fields missed the `treeview`, which is mandantory for `tree-inspector.el`.
The `inspector-pkg.el` after installed from melpa, only contain the `emacs-27.1`.
``` emacs-lisp
(define-package "inspector" "20230316.161633" "Tool for inspection of Emacs Lisp objects"
  '((emacs "27.1"))
...)
```
This PR try to fix the issue. Please help review it, thanks.