### PR TITLE
Only locally bind `revert-buffer-function'

### DIFF
--- a/inspector.el
+++ b/inspector.el
@@ -780,7 +780,7 @@ is expected to be used.")
                       buf))))
     (with-current-buffer buffer
       (add-hook 'xref-backend-functions 'elisp--xref-backend 0 'local)
-      (setq revert-buffer-function #'inspector--revert-buffer)
+      (setq-local revert-buffer-function #'inspector--revert-buffer)
       (setq buffer-read-only nil)
       (erase-buffer))
     buffer))


### PR DESCRIPTION
Setting this variable globally causes #'revert-file to stop working. I got very confused by this, as Emacs was prompting me about a file I was editing having changed on disk, but me being unable to reload it.

Note that this is *not* required for the following line because that variable automatically becomes buffer-local when set.