### PR TITLE
Define command to inspect Help buffer's symbol

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ When on an Emacs debugging backtrace, press letter `i` to inspect the pointed fr
 
 When on edebug-mode, use `C-c C-i` for inspecting expressions in the debugger.
 
+### From Help buffers
+
+When in a *Help* buffer, such as the ones created from `describe-function`, `describe-variable`, `describe-keymap`, and `describe-symbol`, you can use M-x `inspector-inspect-help-buffer-expression` to inspect the symbol associated with that Help buffer.
+
 ### Setup evaluation commands using prefix arguments
 
 Instead of bothering setting up different key bindings for elisp evaluation and inspection, it can be handy to have both in the same command, and use prefix arguments to differenciate, like this:

--- a/inspector.el
+++ b/inspector.el
@@ -46,6 +46,12 @@
 ;; When on an Emacs debugging backtrace, press letter i to inspect the pointed frame and its local variables.
 ;;
 ;; When on edebug-mode, use C-c C-i for inspecting expressions in the debugger.
+;;
+;; From *Help* buffers:
+;;
+;; When in a *Help* buffer, such as the ones created from `describe-function', `describe-variable',
+;; `describe-keymap', and `describe-symbol', you can use M-x `inspector-inspect-help-buffer-expression'
+;; to inspect the symbol associated with that Help buffer.
 
 ;;; Code:
 
@@ -1008,6 +1014,16 @@ The environment used is the one when entering the activation frame at point."
 
 ;; Press 'C-c C-i' to inspect expression in edebug-mode
 (define-key edebug-mode-map (kbd "C-c C-i") #'inspector-inspect-edebug-expression)
+
+;; ----- help-mode---------------------------------------
+
+;;;###autoload
+(defun inspector-inspect-help-buffer-expression ()
+  "Inspect the current *Help* buffer\\='s symbol."
+  (interactive)
+  (if-let* ((expr (plist-get help-mode--current-data :symbol)))
+      (inspector-inspect (eval expr t))
+    (message "No symbol to inspect in Help buffer")))
 
 ;;--------- Inspector mode ---------------------------------
 


### PR DESCRIPTION
This implements suggestion 4 in #35.

Not sure if this should be bound in Help buffers. If it should, then I'm not sure what the key binding should be. Maybe "S" to match "s" (go to source), or "P" to match the "P" binding in inspector buffers?